### PR TITLE
fix: the acroname discoverAndConnect method does not accept None anymore…

### DIFF
--- a/src/pykiso/cli.py
+++ b/src/pykiso/cli.py
@@ -89,13 +89,19 @@ def check_file_extension(click_context: click.Context, param: click.Parameter, p
     return paths
 
 
-def active_threads() -> list[str]:
+def active_threads() -> list[list[str]]:
     """Get the names of all active threads except the main thread."""
-    return [thread.name for thread in threading.enumerate()][1:]
+    frames = sys._current_frames()
+    return [[thread.name, str(frames.get(thread.ident))] for thread in threading.enumerate()][1:]
 
 
-def check_and_handle_unresolved_threads(log: logging.Logger, timeout: int = 10) -> None:
+def check_and_handle_unresolved_threads(log: logging.Logger, exit_code: int, timeout: int = 10) -> None:
     """Check if there are unresolved threads and handle them.
+
+    :param log: logger
+    :param exit_code: exit code to use if unresolved threads are still running after the timeout
+    :param timeout: timeout in seconds to wait for unresolved threads to be terminated
+
     Process for unresolved threads:
     - If there are unresolved threads, log a warning and wait for a timeout.
     - If the threads are still running after the timeout, log a fatal error and force exit.
@@ -106,14 +112,14 @@ def check_and_handle_unresolved_threads(log: logging.Logger, timeout: int = 10) 
 
     if len(running_threads) > 0:
         for thread in running_threads:
-            log.warning(f"Unresolved thread {thread} is still running")
+            log.warning(f"Unresolved thread {thread[0]} is still running. Frame: {thread[1]}")
         log.warning(f"Wait {timeout}s for unresolved threads to be terminated.")
         time.sleep(timeout)
         if threading.active_count() > 1:
             log.fatal(
-                f"Unresolved threads {', '.join(active_threads())} are still running after {timeout} seconds. Force pykiso to Exit."
+                f"Unresolved threads {', '.join([thread[0] for thread in active_threads()])} are still running after {timeout} seconds. Force pykiso to Exit."
             )
-            os._exit(test_execution.ExitCode.UNRESOLVED_THREADS)
+            os._exit(exit_code)
         else:
             log.warning("Unresolved threads has been properly shut down. Normal exit.")
 
@@ -305,6 +311,6 @@ def main(
             if isinstance(handler, logging.FileHandler):
                 logging.getLogger().removeHandler(handler)
 
-        check_and_handle_unresolved_threads(log, timeout=UNRESOLVED_THREAD_TIMEOUT)
+        check_and_handle_unresolved_threads(log, exit_code=exit_code, timeout=UNRESOLVED_THREAD_TIMEOUT)
 
     sys.exit(exit_code)

--- a/src/pykiso/lib/auxiliaries/acroname_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/acroname_auxiliary.py
@@ -72,7 +72,7 @@ class AcronameAuxiliary(AuxiliaryInterface):
     MICROVOLT_TO_UNIT = {"uV": 1, "mV": 1e-3, "V": 1e-6}
     MICROAMP_TO_UNIT = {"uA": 1, "mA": 1e-3, "A": 1e-6}
 
-    def __init__(self, serial_number: str = None, **kwargs):
+    def __init__(self, serial_number: str | int = 0, **kwargs):
         """Constructor
 
         :param serial_number: serial number to connect to as hex string. Example "0x66F4859B"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,7 +116,7 @@ def test_check_and_handle_unresolved_threads_no_unresolved_threads(mocker):
 
 def test_check_and_handle_unresolved_threads_with_unresolved_threads_resolved_before_timeout(mocker):
     log_mock = mocker.MagicMock()
-    mocker.patch("pykiso.cli.active_threads", side_effect=[["Thread-1"], []])
+    mocker.patch("pykiso.cli.active_threads", side_effect=[[("Thread-1", "Thread-1 frame")], []])
     mocker.patch("time.sleep", return_value=None)
     cli.check_and_handle_unresolved_threads(log_mock, 0, timeout=5)
     log_mock.warning.assert_called()
@@ -125,7 +125,7 @@ def test_check_and_handle_unresolved_threads_with_unresolved_threads_resolved_be
 
 def test_check_and_handle_unresolved_threads_with_unresolved_threads_not_resolved_after_timeout(mocker):
     log_mock = mocker.MagicMock()
-    mocker.patch("pykiso.cli.active_threads", return_value=["Thread-1"])
+    mocker.patch("pykiso.cli.active_threads", return_value=[("Thread-1", "Thread-1 frame")])
     mocker.patch("threading.active_count", return_value=2)
     mocker.patch("time.sleep", return_value=None)
     os_mock = mocker.patch("os._exit", return_value=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,7 +109,7 @@ def test_check_file_extension(mocker):
 def test_check_and_handle_unresolved_threads_no_unresolved_threads(mocker):
     log_mock = mocker.MagicMock()
     mocker.patch("pykiso.cli.active_threads", return_value=[])
-    cli.check_and_handle_unresolved_threads(log_mock)
+    cli.check_and_handle_unresolved_threads(log_mock, 0)
     log_mock.warning.assert_not_called()
     log_mock.fatal.assert_not_called()
 
@@ -118,7 +118,7 @@ def test_check_and_handle_unresolved_threads_with_unresolved_threads_resolved_be
     log_mock = mocker.MagicMock()
     mocker.patch("pykiso.cli.active_threads", side_effect=[["Thread-1"], []])
     mocker.patch("time.sleep", return_value=None)
-    cli.check_and_handle_unresolved_threads(log_mock, timeout=5)
+    cli.check_and_handle_unresolved_threads(log_mock, 0, timeout=5)
     log_mock.warning.assert_called()
     log_mock.fatal.assert_not_called()
 
@@ -129,10 +129,10 @@ def test_check_and_handle_unresolved_threads_with_unresolved_threads_not_resolve
     mocker.patch("threading.active_count", return_value=2)
     mocker.patch("time.sleep", return_value=None)
     os_mock = mocker.patch("os._exit", return_value=None)
-    cli.check_and_handle_unresolved_threads(log_mock, timeout=5)
+    cli.check_and_handle_unresolved_threads(log_mock, 0, timeout=5)
     log_mock.warning.assert_called()
     log_mock.fatal.assert_called()
-    os_mock.assert_called_with(cli.test_execution.ExitCode.UNRESOLVED_THREADS)
+    os_mock.assert_called_with(0)
 
 
 def test_active_threads(mocker):
@@ -144,5 +144,5 @@ def test_active_threads(mocker):
     other_thread.configure_mock(name="Thread-1")
 
     mocker.patch("threading.enumerate", return_value=[main_thread, other_thread])
-    actual = cli.active_threads()
+    actual = [thread[0] for thread in cli.active_threads()]
     assert actual == ["Thread-1"]


### PR DESCRIPTION
... use 0 instead.

In the cli the exit code will be passed through since the tests could still have passed. Main issue is the lib lgpio, which opens a thread, as a daemon, and not cl