### PR TITLE
fix: step report issue with TypeError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykiso"
-version = "0.31.0"
+version = "0.31.1"
 description = "Embedded integration testing framework."
 authors = ["Sebastian Fischer <sebastian.fischer@de.bosch.com>"]
 license = "Eclipse Public License - v 2.0"
@@ -40,7 +40,7 @@ unittest-xml-reporting = "^3.2.0"
 click = ">=7.0.0,<9.0.0"
 tabulate = ">=0.8.9,<0.10.0"
 Jinja2 = ">=2.11.0,<4.0.0"
-MarkupSafe = "~2.0.1" # Allow support for Jinja2 between 2.11 < x < 3
+MarkupSafe = "~2.0.1"                                                          # Allow support for Jinja2 between 2.11 < x < 3
 importlib-metadata = { version = ">=4.12,<7.0", python = "<3.8" }
 pyreadline3 = { version = "^3.4.1", python = "^3.5" }
 hidapi = ">=0.12,<0.15"
@@ -116,7 +116,7 @@ pykiso-tags = 'pykiso.tool.show_tag:main'
 instrument-control = 'pykiso.lib.auxiliaries.instrument_control_auxiliary.instrument_control_cli:main'
 pykitest = 'pykiso.tool.pykiso_to_pytest.cli:main'
 testrail = "pykiso.tool.testrail.cli:cli_testrail"
-xray = "pykiso.tool.xray.cli:cli_xray" # cli xray
+xray = "pykiso.tool.xray.cli:cli_xray"                                                                 # cli xray
 
 [tool.poetry.plugins]
 pytest11 = { pytest_kiso = "pykiso.pytest_plugin" }

--- a/src/pykiso/test_coordinator/test_case.py
+++ b/src/pykiso/test_coordinator/test_case.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import functools
 import logging
 import unittest
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 import lxml
@@ -127,6 +128,27 @@ class BasicTest(unittest.TestCase):
     @properties.deleter
     def properties(self):
         del self._properties
+
+    # Overwrite the deprecate function to keep the signature for step report
+    @staticmethod
+    def _deprecate(original_func):
+        @functools.wraps(original_func)
+        def deprecated_func(*args, **kwargs):
+            warnings.warn("Please use {0} instead.".format(original_func.__name__), DeprecationWarning, 2)
+            return original_func(*args, **kwargs)
+
+        return deprecated_func
+
+    failUnlessEqual = assertEquals = _deprecate(unittest.TestCase.assertEqual)
+    failIfEqual = assertNotEquals = _deprecate(unittest.TestCase.assertNotEqual)
+    failUnlessAlmostEqual = assertAlmostEquals = _deprecate(unittest.TestCase.assertAlmostEqual)
+    failIfAlmostEqual = assertNotAlmostEquals = _deprecate(unittest.TestCase.assertNotAlmostEqual)
+    failUnless = assert_ = _deprecate(unittest.TestCase.assertTrue)
+    failUnlessRaises = _deprecate(unittest.TestCase.assertRaises)
+    failIf = _deprecate(unittest.TestCase.assertFalse)
+    assertRaisesRegexp = _deprecate(unittest.TestCase.assertRaisesRegex)
+    assertRegexpMatches = _deprecate(unittest.TestCase.assertRegex)
+    assertNotRegexpMatches = _deprecate(unittest.TestCase.assertNotRegex)
 
 
 class RemoteTest(BasicTest):

--- a/tests/test_assert_step_report.py
+++ b/tests/test_assert_step_report.py
@@ -27,9 +27,7 @@ def test_case():
     tc.assertAlmostEqual = assert_step_report.assert_decorator(tc.assertAlmostEqual)
 
     # Add the step-report parameters
-    tc.step_report = assert_step_report.StepReportData(
-        header={}, message="", success=True, current_table=None
-    )
+    tc.step_report = assert_step_report.StepReportData(header={}, message="", success=True, current_table=None)
 
     return tc
 
@@ -53,9 +51,7 @@ def remote_test_case(mocker):
     tc.assertEqual = assert_step_report.assert_decorator(tc.assertEqual)
 
     # Add the step-report parameters
-    tc.step_report = assert_step_report.StepReportData(
-        header={}, message="", success=True, current_table=None
-    )
+    tc.step_report = assert_step_report.StepReportData(header={}, message="", success=True, current_table=None)
     return tc
 
 
@@ -140,9 +136,9 @@ def test_assert_decorator_reraise(mocker, test_case):
         test_case.assertTrue(data_to_test, msg="Dummy message")
 
     assert (
-        assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"][
-            "test_assert_decorator_reraise"
-        ]["steps"][-1][-1]["succeed"]
+        assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"]["test_assert_decorator_reraise"]["steps"][-1][-1][
+            "succeed"
+        ]
         == False
     )
     step_result.assert_called_once_with(
@@ -175,9 +171,7 @@ def test_assert_decorator_no_var_name(mocker, test_case):
 
     test_case.assertTrue(True)
 
-    step_result.assert_called_once_with(
-        "TestCase", "test_assert_decorator_no_var_name", "", "True", "True", True
-    )
+    step_result.assert_called_once_with("TestCase", "test_assert_decorator_no_var_name", "", "True", "True", True)
 
 
 def test_assert_decorator_index_error(mocker, test_case):
@@ -196,9 +190,7 @@ def test_assert_decorator_multi_input(mocker, test_case):
 
     data_to_test = 4.5
     data_expected = 4.5
-    test_case.assertAlmostEqual(
-        data_to_test, data_expected, delta=1, msg="Test the step report"
-    )
+    test_case.assertAlmostEqual(data_to_test, data_expected, delta=1, msg="Test the step report")
 
     step_result.assert_called_once_with(
         "TestCase",
@@ -216,9 +208,7 @@ def test_generate(mocker, test_result):
     assert_step_report.ALL_STEP_REPORT["TestClassName"]["time_result"] = OrderedDict()
     assert_step_report.ALL_STEP_REPORT["TestClassName"]["time_result"]["Start Time"] = 1
     assert_step_report.ALL_STEP_REPORT["TestClassName"]["time_result"]["End Time"] = 2
-    assert_step_report.ALL_STEP_REPORT["TestClassName"]["time_result"][
-        "Elapsed Time"
-    ] = 1
+    assert_step_report.ALL_STEP_REPORT["TestClassName"]["time_result"]["Elapsed Time"] = 1
 
     jinja2.FileSystemLoader = mock_loader = mock.MagicMock()
     jinja2.Environment = mock_environment = mock.MagicMock()
@@ -234,12 +224,10 @@ def test_generate(mocker, test_result):
 def test_add_step():
     assert_step_report.ALL_STEP_REPORT["TestCase"] = OrderedDict()
     assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"] = OrderedDict()
-    assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"][
-        "test_assert_step_report_multi_input"
-    ] = {}
-    steplist = assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"][
-        "test_assert_step_report_multi_input"
-    ]["steps"] = [[]]
+    assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"]["test_assert_step_report_multi_input"] = {}
+    steplist = assert_step_report.ALL_STEP_REPORT["TestCase"]["test_list"]["test_assert_step_report_multi_input"][
+        "steps"
+    ] = [[]]
 
     assert_step_report._add_step(
         "TestCase",
@@ -333,13 +321,9 @@ def test_add_retry_information(mocker, result_test):
     }
     assert_step_report.ALL_STEP_REPORT = all_step_report_mock
 
-    assert_step_report.add_retry_information(
-        mock_test_case_class, result_test, retry_nb, max_try, ValueError
-    )
+    assert_step_report.add_retry_information(mock_test_case_class, result_test, retry_nb, max_try, ValueError)
 
-    test_info = assert_step_report.ALL_STEP_REPORT[type(mock_test_case_class).__name__][
-        "test_list"
-    ]["test_run"]
+    test_info = assert_step_report.ALL_STEP_REPORT[type(mock_test_case_class).__name__]["test_list"]["test_run"]
     assert test_info["steps"] == [
         [{"succeed": False}, {"succeed": True}],
         [],
@@ -351,10 +335,45 @@ def test_add_retry_information(mocker, result_test):
     assert test_info["max_try"] == max_try
     assert test_info["number_try"] == retry_nb + 1
 
-    assert (
-        assert_step_report.ALL_STEP_REPORT[type(mock_test_case_class).__name__][
-            "succeed"
-        ]
-        == result_test
-    )
+    assert assert_step_report.ALL_STEP_REPORT[type(mock_test_case_class).__name__]["succeed"] == result_test
     format_exec_mock.assert_called_once()
+
+
+def test_assert_decorator_step_report_message_deprecated(mocker, remote_test_case):
+    step_result = mocker.patch("pykiso.test_result.assert_step_report._add_step")
+    remote_test_case.assertEquals = assert_step_report.assert_decorator(remote_test_case.assertEquals)
+
+    var = "Test"
+    expected_var = "Test"
+    remote_test_case.assertEquals(var, expected_var, "not expected str")
+
+    assert step_result.call_count == 1
+    step_result.assert_called_once_with(
+        "RemoteTest",
+        "test_assert_decorator_step_report_message_deprecated",
+        "not expected str",
+        "var",
+        "Equals to Test",
+        "Test",
+    )
+
+
+def test_assert_decorator_step_report_assert_called_in_unittest(mocker, remote_test_case):
+    step_result = mocker.patch("pykiso.test_result.assert_step_report._add_step")
+    remote_test_case.assertEqual = assert_step_report.assert_decorator(remote_test_case.assertEqual)
+    remote_test_case.assertMultiLineEqual = assert_step_report.assert_decorator(remote_test_case.assertMultiLineEqual)
+    remote_test_case.assertIsInstance = assert_step_report.assert_decorator(remote_test_case.assertIsInstance)
+
+    var = "Test"
+    expected_var = "Test"
+    remote_test_case.assertEqual(var, expected_var, "not expected str")
+
+    assert step_result.call_count == 1
+    step_result.assert_called_once_with(
+        "RemoteTest",
+        "test_assert_decorator_step_report_assert_called_in_unittest",
+        "not expected str",
+        "var",
+        "Equal to Test",
+        "Test",
+    )


### PR DESCRIPTION
### Assert function called in unittest : 
Current step report result for following test : 
![image](https://github.com/user-attachments/assets/642ccb26-5c2b-4672-b30d-8bc0bbdb21d8)
Give the following result : 
![image](https://github.com/user-attachments/assets/cdf89a9b-abc0-4437-a520-70423c64f4e5)


Because the self.assertEqual calls other assert function inside unittest so now if the function is called inside unittest.case we just execute the function normally.

### Assert function deprecated 
There was also issue if users were using deprecated function then the variable name was not found since the function name will be `deprecated_fun` and the signature was not defined in the decorator used by unittest to deprecate the function.
So now overwrite the deprecated function with a decorator that keeps the signature and retry to find variable name by using the depecrated function name.

