### PR TITLE
Fix/itf socket can logging

### DIFF
--- a/src/pykiso/lib/connectors/cc_socket_can/socketcan_to_trc.py
+++ b/src/pykiso/lib/connectors/cc_socket_can/socketcan_to_trc.py
@@ -106,6 +106,8 @@ class SocketCan2Trc(can.Listener):
 
     def start(self):
         """start logging"""
+        if self.started:
+            return
         self.open_trc_file()
 
         self.starttime = self.get_start_time()

--- a/src/pykiso/lib/connectors/cc_socket_can/socketcan_to_trc.py
+++ b/src/pykiso/lib/connectors/cc_socket_can/socketcan_to_trc.py
@@ -94,11 +94,15 @@ class SocketCan2Trc(can.Listener):
         """cleanup logger"""
         if not self.started:
             return
+        # Remove the listener else the Can Notifier stop function will call this stop function
+        # which then call again the Can Notifier again etc, and python is in an infinite loop
+        self.can_notifier.remove_listener(self)
         self.can_notifier.stop()
         self.can_notifier = None
         if self.trc_file != sys.stdout:
             self.trc_file.close()
         self.bus = None
+        self.started = False
 
     def start(self):
         """start logging"""


### PR DESCRIPTION
Fix case where the closing of CCSocketCan could be stuck in an infinite loop if the trace was active.
And add a check in case the trace was already started to not try to start a second time.

Fix will be released in 0.31.2 with another fix for UDSBaseAuxiliary so this is why the tag isn't increased.