### PR TITLE
Bugfix/itf bugfix active uds auxiliary when specified in yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykiso"
-version = "0.31.1"
+version = "0.31.2"
 description = "Embedded integration testing framework."
 authors = ["Sebastian Fischer <sebastian.fischer@de.bosch.com>"]
 license = "Eclipse Public License - v 2.0"

--- a/src/pykiso/lib/auxiliaries/udsaux/common/uds_base_auxiliary.py
+++ b/src/pykiso/lib/auxiliaries/udsaux/common/uds_base_auxiliary.py
@@ -98,8 +98,8 @@ class UdsBaseAuxiliary(AuxiliaryInterface):
         :param tp_layer: isotp configuration given at yaml level
         :param uds_layer: uds configuration given at yaml level
         """
-        tp_layer = tp_layer or UdsBaseAuxiliary.DEFAULT_TP_CONFIG
-        uds_layer = uds_layer or UdsBaseAuxiliary.DEFAULT_UDS_CONFIG
+        tp_layer = tp_layer or UdsBaseAuxiliary.DEFAULT_TP_CONFIG.copy()
+        uds_layer = uds_layer or UdsBaseAuxiliary.DEFAULT_UDS_CONFIG.copy()
         # add configured request id and response id to tp layer config
         tp_layer["req_id"] = self.req_id
         tp_layer["res_id"] = self.res_id


### PR DESCRIPTION
Fix case where the wrong id could be used because the init modify the Variable class DEFAULT_TP_CONFIG by adding the req and res id and assigning it to self.tp_layer. 
So if an auxiliary is stopped and started again it may take the id of an other UDS auxiliary defined.