### PR TITLE
Feature/parameterized tests with xray poc

### DIFF
--- a/docs/tools/xray.rst
+++ b/docs/tools/xray.rst
@@ -4,7 +4,7 @@
 Export results to Xray
 ======================
 
-The ``xray`` CLI utility takes your Pykiso Junit report and export them on `Xray <https://xray.cloud.getxray.app/>`__.
+The ``xray`` CLI utility takes your Pykiso Junit test results report and export them on `Xray <https://xray.cloud.getxray.app/>`__.
 
 Upload your results
 -------------------
@@ -12,15 +12,13 @@ To upload your results to Xray users have to follow the command :
 
 .. code:: bash
 
-    xray --user USER_ID --password MY_API_KEY --url https://xray.cloud.getxray.app/ upload  --path-results path/to/reports/folder --test-execution-id "BDU3-12345"
-    --project-key KEY
+    xray --user USER_ID --password MY_API_KEY --url "https://xray.cloud.getxray.app/" upload --path-results path/reports/folder --test-execution-id
 
 Options:
   --user TEXT                   Xray user id  [required]
   --password TEXT               Valid Xray API key (if not given ask at command prompt
                                 level)  [optional]
   --url TEXT                    URL of Xray server  [required]
-  --project-key TEXT            Key of the project  [required]
   --path-results PATH           Full path to the folder containing the JUNIT reports
                                 [required]
   --test-execution-id TEXT      Xray test execution ticket id's use to import the
@@ -32,3 +30,45 @@ Options:
 
 
 The above command will create a new test execution ticket on Xray side or overwrite an existing one with the test results.
+
+Tests without parameterized:
+
+.. code:: python
+
+  @pykiso.define_test_parameters(suite_id=1, case_id=1, aux_list=[aux1])
+  class MyTest0(pykiso.RemoteTest):
+      @pykiso.xray(test_key="ABC-123")
+      def test_0(self, name):
+          """Test run 1: parameterized test to check the assert true"""
+          is_true = True
+          self.assertTrue(is_true, f"{is_true} should start be True")
+
+
+For this test on Xray, 1 test execution tickets will be created, for all the test cases.
+
+Tests with parametrized:
+
+.. code:: python
+
+  @pykiso.define_test_parameters(suite_id=1, case_id=1, aux_list=[aux1])
+  class MyTest1(pykiso.RemoteTest):
+      @parameterized.expand([("dummy_1"), ("dunny_1")])
+      @pykiso.xray(test_key="ABC-456")
+      def test_1(self, name):
+          """Test run 1: parameterized test to check the assert true"""
+          self.assertTrue(name.startswith("dummy"), f"{name} should start with dummy")
+
+
+  @pykiso.define_test_parameters(suite_id=1, case_id=2, aux_list=[aux2])
+  class MyTest2(pykiso.RemoteTest):
+      @pykiso.xray(test_key="ABC-789")
+      def test_2(self):
+          """Test run 2: not parametrized test"""
+          is_true = False
+          print(f"is_true= {is_true}")
+          self.assertTrue(is_true, f"{is_true} should be True")
+
+      def tearDown(self):
+          super().tearDown()
+
+For this test on Xray, 4 test execution tickets will be created, one per test cases.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1398,7 +1398,6 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
-    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 
@@ -2183,23 +2182,6 @@ files = [
 ]
 
 [[package]]
-name = "roman-numerals-py"
-version = "3.1.0"
-description = "Manipulate well-formed Roman numerals"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-markers = "python_version >= \"3.11\""
-files = [
-    {file = "roman_numerals_py-3.1.0-py3-none-any.whl", hash = "sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c"},
-    {file = "roman_numerals_py-3.1.0.tar.gz", hash = "sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d"},
-]
-
-[package.extras]
-lint = ["mypy (==1.15.0)", "pyright (==1.1.394)", "ruff (==0.9.7)"]
-test = ["pytest (>=8)"]
-
-[[package]]
 name = "ruff"
 version = "0.2.1"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -2291,7 +2273,6 @@ description = "Python documentation generator"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
-markers = "python_version == \"3.10\""
 files = [
     {file = "sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2"},
     {file = "sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927"},
@@ -2322,50 +2303,12 @@ lint = ["flake8 (>=6.0)", "mypy (==1.11.1)", "pyright (==1.1.384)", "pytest (>=6
 test = ["cython (>=3.0)", "defusedxml (>=0.7.1)", "pytest (>=8.0)", "setuptools (>=70.0)", "typing_extensions (>=4.9)"]
 
 [[package]]
-name = "sphinx"
-version = "8.2.3"
-description = "Python documentation generator"
-optional = false
-python-versions = ">=3.11"
-groups = ["dev"]
-markers = "python_version >= \"3.11\""
-files = [
-    {file = "sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3"},
-    {file = "sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348"},
-]
-
-[package.dependencies]
-alabaster = ">=0.7.14"
-babel = ">=2.13"
-colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
-docutils = ">=0.20,<0.22"
-imagesize = ">=1.3"
-Jinja2 = ">=3.1"
-packaging = ">=23.0"
-Pygments = ">=2.17"
-requests = ">=2.30.0"
-roman-numerals-py = ">=1.0.0"
-snowballstemmer = ">=2.2"
-sphinxcontrib-applehelp = ">=1.0.7"
-sphinxcontrib-devhelp = ">=1.0.6"
-sphinxcontrib-htmlhelp = ">=2.0.6"
-sphinxcontrib-jsmath = ">=1.0.1"
-sphinxcontrib-qthelp = ">=1.0.6"
-sphinxcontrib-serializinghtml = ">=1.1.9"
-
-[package.extras]
-docs = ["sphinxcontrib-websupport"]
-lint = ["betterproto (==2.0.0b6)", "mypy (==1.15.0)", "pypi-attestations (==0.0.21)", "pyright (==1.1.395)", "pytest (>=8.0)", "ruff (==0.9.9)", "sphinx-lint (>=0.9)", "types-Pillow (==10.2.0.20240822)", "types-Pygments (==2.19.0.20250219)", "types-colorama (==0.4.15.20240311)", "types-defusedxml (==0.7.0.20240218)", "types-docutils (==0.21.0.20241128)", "types-requests (==2.32.0.20241016)", "types-urllib3 (==1.26.25.14)"]
-test = ["cython (>=3.0)", "defusedxml (>=0.7.1)", "pytest (>=8.0)", "pytest-xdist[psutil] (>=3.4)", "setuptools (>=70.0)", "typing_extensions (>=4.9)"]
-
-[[package]]
 name = "sphinx-autodoc-typehints"
 version = "3.0.1"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
-markers = "python_version == \"3.10\""
 files = [
     {file = "sphinx_autodoc_typehints-3.0.1-py3-none-any.whl", hash = "sha256:4b64b676a14b5b79cefb6628a6dc8070e320d4963e8ff640a2f3e9390ae9045a"},
     {file = "sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55"},
@@ -2377,26 +2320,6 @@ sphinx = ">=8.1.3"
 [package.extras]
 docs = ["furo (>=2024.8.6)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "defusedxml (>=0.7.1)", "diff-cover (>=9.2.1)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "sphobjinv (>=2.3.1.2)", "typing-extensions (>=4.12.2)"]
-
-[[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.1.0"
-description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
-optional = false
-python-versions = ">=3.11"
-groups = ["dev"]
-markers = "python_version >= \"3.11\""
-files = [
-    {file = "sphinx_autodoc_typehints-3.1.0-py3-none-any.whl", hash = "sha256:67bdee7e27ba943976ce92ebc5647a976a7a08f9f689a826c54617b96a423913"},
-    {file = "sphinx_autodoc_typehints-3.1.0.tar.gz", hash = "sha256:a6b7b0b6df0a380783ce5b29150c2d30352746f027a3e294d37183995d3f23ed"},
-]
-
-[package.dependencies]
-sphinx = ">=8.2"
-
-[package.extras]
-docs = ["furo (>=2024.8.6)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.6.12)", "defusedxml (>=0.7.1)", "diff-cover (>=9.2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "sphobjinv (>=2.3.1.2)", "typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "sphinx-rtd-theme"
@@ -2943,6 +2866,18 @@ files = [
     {file = "wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3"},
 ]
 
+[[package]]
+name = "xmltodict"
+version = "0.14.2"
+description = "Makes working with XML feel like you are working with JSON"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac"},
+    {file = "xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553"},
+]
+
 [extras]
 all = ["PyVISA", "PyVISA-py", "black", "grpcio", "isort", "protobuf", "pykiso-python-uds", "pylink-square", "pyserial", "python-can", "requests", "rich"]
 can = ["pykiso-python-uds", "python-can"]
@@ -2957,4 +2892,4 @@ testrail = ["requests", "rich"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "294ac1c39248178f73131bda32169473fe49de7fbc5d3eb41f8a6364e4d19de4"
+content-hash = "9908424e4baa7a4be65f157993b8f7b0e3f66b49c4a7eae63bee00169c4e2108"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykiso"
-version = "1.1.3"
+version = "1.2.0"
 description = "Embedded integration testing framework."
 authors = ["Sebastian Fischer <sebastian.fischer@de.bosch.com>"]
 license = "Eclipse Public License - v 2.0"
@@ -61,6 +61,7 @@ unittest-xml-reporting = "^3.2.0"
 viztracer=  "^1.0.1"
 fastapi = "^0.115.3"
 uvicorn = "^0.32.0"
+xmltodict = "^0.14.2"
 
 [tool.poetry.extras]
 plugins = [

--- a/src/pykiso/tool/xray/cli.py
+++ b/src/pykiso/tool/xray/cli.py
@@ -54,13 +54,6 @@ def cli_xray(ctx: dict, user: str, password: str, url: str) -> None:
     required=True,
 )
 @click.option(
-    "-k",
-    "--project-key",
-    help="Key of the project",
-    type=click.STRING,
-    required=True,
-)
-@click.option(
     "-n",
     "--test-execution-name",
     help="Name of the test execution ticket created",
@@ -87,16 +80,26 @@ def cli_upload(
     ctx,
     path_results: str,
     test_execution_id: str,
-    project_key: str,
     test_execution_name: str,
     merge_xml_files: bool,
     import_description: bool,
 ) -> None:
-    """Upload the JUnit xml test results on xray."""
-    # From the JUnit xml files found, create a temporary file to keep only the test results marked with an xray decorator.
+    """Upload the JUnit xml test results on xray.
+
+    :param ctx: click context
+    :param path_results: path to the junit xml files containing the test result reports
+    :param test_execution_id: test execution ID where to upload the test results
+    :param test_execution_name: name of the test execution ticket
+    :param merge_xml_files: if True, merge the xml files, else do nothing
+    :param import_description: if True, change the ticket description with the test function description
+    """
+    # From the JUnit xml files found, create a list of the dictionary per test results marked with an xray decorator.
     path_results = Path(path_results).resolve()
     test_results = extract_test_results(
-        path_results=path_results, merge_xml_files=merge_xml_files, update_description=import_description
+        path_results=path_results,
+        merge_xml_files=merge_xml_files,
+        update_description=import_description,
+        test_execution_id=test_execution_id,
     )
 
     responses = []
@@ -108,8 +111,6 @@ def cli_upload(
                 user=ctx.obj["USER"],
                 password=ctx.obj["PASSWORD"],
                 results=result,
-                test_execution_id=test_execution_id,
-                project_key=project_key,
                 test_execution_name=test_execution_name,
             )
         )

--- a/src/pykiso/tool/xray/xray.py
+++ b/src/pykiso/tool/xray/xray.py
@@ -1,109 +1,106 @@
 import json
 import tempfile
 from pathlib import Path
-from xml.etree import ElementTree as ET
 
 import requests
+import xmltodict
 from junitparser.cli import merge as merge_junit_xml
+from requests.auth import AuthBase
+
+from ...tool.xray.xray_report import create_result_dictionary, reformat_xml_results
 
 API_VERSION = "api/v2/"
+AUTHENTICATE_ENDPOINT = "/api/v2/authenticate"
 
 
 class XrayException(Exception):
     """Raise when sending the post request is unsuccessful."""
 
+    def __init__(self, message=""):
+        self.message = message
+
+
+class ClientSecretAuth(AuthBase):
+    """Bearer authentication with Client ID and a Client Secret."""
+
+    def __init__(self, base_url: str, client_id: str, client_secret: str, verify: bool | str = True) -> None:
+        if base_url.endswith("/"):
+            base_url = base_url[:-1]
+        self.base_url = base_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.verify = verify
+
+    @property
+    def endpoint_url(self) -> str:
+        """Return full URL to the authenticate server."""
+        return f"{self.base_url}{AUTHENTICATE_ENDPOINT}"
+
+    def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
+        headers = {"Content-type": "application/json", "Accept": "text/plain"}
+        auth_data = {"client_id": self.client_id, "client_secret": self.client_secret}
+
+        try:
+            response = requests.post(self.endpoint_url, data=json.dumps(auth_data), headers=headers, verify=self.verify)
+        except requests.exceptions.ConnectionError as exc:
+            err_message = f"ConnectionError: cannot authenticate with {self.endpoint_url}"
+            raise XrayException(err_message) from exc
+        else:
+            auth_token = response.text.replace('"', "")
+            r.headers["Authorization"] = f"Bearer {auth_token}"
+        return r
+
 
 class XrayPublisher:
     """Xray Publisher command API."""
 
-    def __init__(self, base_url: str, client_id: str, client_secret: str) -> None:
+    def __init__(self, base_url: str, endpoint: str, auth: ClientSecretAuth, verify: bool | str = True) -> None:
         self.base_url = base_url[:-1] if base_url.endswith("/") else base_url
+        self.endpoint = endpoint
         self.rest_api_version = API_VERSION
-        self.client_id = client_id
-        self.client_secret = client_secret
+        self.auth = auth
+        self.verify = verify
 
-    def get_url(self, url_endpoint: str) -> str:
-        """
-        Get the complete url to send the post request.
-
-        :param url_endpoint: the endpoint of the url
-
-        :return: the complete url to send the post request
-        """
-        return f"{self.base_url}/{self.rest_api_version}{url_endpoint}"
-
-    def get_token(self, url: str) -> str:
-        """
-        Get the token to authenticate to xray from a client ID and a client SECRET.
-
-        :param url: the url to send the post request to authenticate
-        :raises HTTPError: if the token couldn't be retrieved
-        :return: the Bearer token
-        """
-        client = {"client_id": self.client_id, "client_secret": self.client_secret}
-        headers = {"Content-Type": "application/json"}
-        token_result = requests.post(url=url, headers=headers, json=client)
-        token_result.raise_for_status()
-        return token_result.json()
-
-    def get_publisher_headers(self, token: str) -> dict[str, str]:
-        """
-        Get the request header by adding content and authorization part.
-
-        :param token: the requested Bearer token
-
-        :return: the post request's header
-        """
-        headers = {"Authorization": "Bearer " + token}
-        headers["Content-Type"] = "test/xml"
-        return headers
+    @property
+    def endpoint_url(self) -> str:
+        """Return full URL complete url to send the post request.to the xray server."""
+        return self.base_url + self.endpoint
 
     def publish_xml_result(
         self,
-        token: str,
         data: dict,
-        project_key: str,
-        test_execution_id: str | None = None,
+        project_key: str | None = None,
         test_execution_name: str | None = None,
     ) -> dict[str, str]:
         """
         Publish the xml test results to xray.
 
-        :param token: the requested Bearer token
         :param data: the test results
+        :param project_key: the xray's project key
         :param test_execution_id: the xray's test execution ticket id where to import the test results,
             if none is specified a new test execution ticket will be created
-
+        :param test_execution_name: the xray's test execution ticket summary
+            if none is specified a `Execution of automated tests` is used
         :return: the content of the post request to create the execution test ticket: its id, its key, and its issue
         """
+        print("Uploading test results to Xray...")
         if test_execution_name is None:
-            return self._publish_xml_result(
-                token=token, data=data, project_key=project_key, test_execution_id=test_execution_id
-            )
+            return self._publish_xml_result(data=data)
         return self._publish_xml_result_multipart(
-            token=token,
             data=data,
             project_key=project_key,
             test_execution_name=test_execution_name,
         )
 
-    def _publish_xml_result(
-        self, token: str, data: dict, project_key: str, test_execution_id: str | None = None
-    ) -> dict[str, str]:
+    def _publish_xml_result(self, data: dict) -> dict[str, str]:
         # construct the request header
-        headers = self.get_publisher_headers(token)
-
-        url_endpoint = f"import/execution/junit/?projectKey={project_key}"
-        if test_execution_id is not None:
-            url_endpoint += f"&testExecKey={test_execution_id}"
-
-        # construct the complete url to send the post request
-        url_publisher = self.get_url(url_endpoint=url_endpoint)
-
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
         try:
-            query_response = requests.post(url=url_publisher, headers=headers, data=data)
+            query_response = requests.request(
+                method="POST", url=self.endpoint, headers=headers, json=data, auth=self.auth, verify=self.verify
+            )
         except requests.exceptions.ConnectionError:
-            raise XrayException(f"Cannot connect to JIRA service at {url_endpoint}")
+            raise XrayException(f"Cannot connect to JIRA service at {self.endpoint}")
         else:
             query_response.raise_for_status()
 
@@ -111,15 +108,14 @@ class XrayPublisher:
 
     def _publish_xml_result_multipart(
         self,
-        token: str,
         data: dict,
         project_key: str,
         test_execution_name: str,
     ):
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
         # construct the request header
-        headers = {"Authorization": "Bearer " + token}
         url_endpoint = "import/execution/junit/multipart"
-        url_publisher = self.get_url(url_endpoint="import/execution/junit/multipart")
+        url_publisher = f"{self.base_url}/{self.rest_api_version}{url_endpoint}"
         files = {
             "info": json.dumps(
                 {
@@ -155,8 +151,7 @@ def upload_test_results(
     user: str,
     password: str,
     results: str,
-    project_key: str,
-    test_execution_id: str | None = None,
+    project_key: str | None = None,
     test_execution_name: str | None = None,
 ) -> dict[str, str]:
     """
@@ -166,27 +161,26 @@ def upload_test_results(
     :param user: the user's session id
     :param password: the user's password
     :param results: the test results
-    :param test_execution_id: the xray's test execution ticket id where to import the test results,
-        if none is specified a new test execution ticket will be created
 
     :return: the content of the post request to create the execution test ticket: its id, its key, and its issue
     """
-    xray_publisher = XrayPublisher(base_url=base_url, client_id=user, client_secret=password)
+    endpoint_url = "https://xray.cloud.getxray.app/api/v2/import/execution"
     # authenticate: get the correct token from the authenticate endpoint
-    url_authenticate = xray_publisher.get_url(url_endpoint="authenticate/")
-    token = xray_publisher.get_token(url=url_authenticate)
-    # publish: post request to send the junit xml result to the junit xml endpoint
+    client_secret_auth = ClientSecretAuth(base_url=base_url, client_id=user, client_secret=password, verify=True)
+    xray_publisher = XrayPublisher(base_url=base_url, endpoint=endpoint_url, auth=client_secret_auth)
+
+    # publish: post request to send the test results to xray endpoint
     responses = xray_publisher.publish_xml_result(
-        token=token,
         data=results,
         project_key=project_key,
-        test_execution_id=test_execution_id,
         test_execution_name=test_execution_name,
     )
     return responses
 
 
-def extract_test_results(path_results: Path, merge_xml_files: bool, update_description: bool) -> list[str]:
+def extract_test_results(
+    path_results: Path, merge_xml_files: bool, update_description: bool, test_execution_id: str | None = None
+) -> list[str]:
     """
     Extract the test results linked to an xray test key. Filter the JUnit xml files generated by the execution of tests,
     to keep only the results of tests marked with an xray decorator. A temporary file is created with the test results.
@@ -195,6 +189,8 @@ def extract_test_results(path_results: Path, merge_xml_files: bool, update_descr
     :param merge_xml_files: merge all the files to return only a list with one element
     :param update_description: if True update the test description format of the xml element to be imported in the xray
         ticket description, if False the test description format is not corrected and it is not imported
+    :param test_execution_id: the xray's test execution ticket id where to import the test results,
+        if none is specified a new test execution ticket will be created
 
     :return: the filtered test results"""
     xml_results = []
@@ -215,39 +211,13 @@ def extract_test_results(path_results: Path, merge_xml_files: bool, update_descr
             xml_path = xml_dir / "xml_merged.xml"
             merge_junit_xml(file_to_parse, xml_path, None)
             file_to_parse = [xml_path]
-        # from the JUnit xml files, create a temporary file
+
+        # use xml to json
         for file in file_to_parse:
-            tree = ET.ElementTree()
-            tree.parse(file)
-            root = tree.getroot()
-            # scan all the xml to keep the testsuite with the property "test_key"
-            for testsuite in root.findall("testsuite"):
-                testcase = testsuite.find("testcase")
-                properties = testcase.find("properties")
-                if properties is None:
-                    # remove the testsuite not marked by the xray decorator
-                    tree.getroot().remove(testsuite)
-                    continue
-                is_xray = False
-                for property in properties.findall("property"):
-                    if property.attrib.get("name") == "test_key":
-                        is_xray = True
-                        break
-                if not is_xray:
-                    # remove the testsuite not marked by the xray decorator
-                    tree.getroot().remove(testsuite)
+            with open(path_results) as xml_file:
+                data_dict = xmltodict.parse(xml_file.read(), attr_prefix="")
 
-            if update_description:
-                # update the test_description property element: name and value attributes become name with the description as property text
-                for property in root.iter("property"):
-                    if property.attrib.get("name") == "test_description":
-                        test_description = property.attrib["value"]
-                        del property.attrib["value"]
-                        property.text = test_description
-
-            with tempfile.TemporaryFile() as fp:
-                tree.write(fp)
-                fp.seek(0)
-                xml_results.append(fp.read().decode())
-
+            xray_dict = create_result_dictionary(data_dict["testsuites"]["testsuite"])
+            # if tests are parameterized, split into one test execution per parameter
+            xml_results = reformat_xml_results(xray_dict, test_execution_id)
         return xml_results

--- a/src/pykiso/tool/xray/xray_report.py
+++ b/src/pykiso/tool/xray/xray_report.py
@@ -1,0 +1,258 @@
+"""
+Create the Xray dictionary from the junit test results
+******************************************************
+
+:module: xray_report
+
+:synopsis: Provide the methods to send the test results report to the Xray REST API endpoint
+
+..currentmodule:: xray_report
+
+"""
+
+from datetime import datetime, timedelta
+
+
+def convert_test_status_to_xray_format(is_successful: bool) -> str:
+    """Convert a boolean test result status to the corresponding XRAY format string.
+
+    :param is_successful: The test result status. True if the test was successful, False otherwise.
+    :return: "PASSED" if the test was successful, "FAILED" if the test was not.
+    """
+    match is_successful:
+        case True:
+            return "PASSED"
+        case False:
+            return "FAILED"
+
+
+def merge_results(test_results: list[dict]) -> None:
+    """
+    Merges a list of test result dictionaries by combining test cases with the same info value.
+    :param test_results: A list of dictionaries where each dictionary contains 'info' (a dictionary of test metadata)
+        and 'tests' (a list of test cases).
+    :return: A list of merged test result dictionaries. Each dictionary contains  info' (a dictionary of test metadata)
+        and 'tests' (a combined list of test cases from all input dictionaries with the same 'info').
+    """
+    merged_results = []
+    info_dict = {}
+
+    for result in test_results:
+        info = result["info"]
+        info_key = tuple(sorted(info.items()))  # Convert dict to a tuple of sorted items to use as a key
+        if info_key in info_dict:
+            info_dict[info_key]["tests"].extend(result["tests"])
+        else:
+            new_entry = {"info": info, "tests": result["tests"]}
+            info_dict[info_key] = new_entry
+            merged_results.append(new_entry)
+
+    return merged_results
+
+
+def get_test_key_from_property(property: list) -> None | str:
+    """
+    Extracts the value of the "test_key" property from a list of property dictionaries.
+
+    :param property: A list of dictionaries, where each dictionary represents a property
+        with "name" and "value" keys.
+
+    :return: None | str: The value of the "test_key" property if found, otherwise None.
+    """
+    test_key = None
+    for p in property:
+        if p["name"] == "test_key":
+            test_key = p["value"]
+            break
+    return test_key
+
+
+def compute_end_time(start_time: str, duration: float) -> str:
+    """
+    Computes the end time by adding a duration to a given start time.
+
+    :param start_time: The start time in ISO 8601 format (e.g., "YYYY-MM-DDTHH:MM:SS").
+        If the timezone offset is not provided, "+0000" (UTC) is assumed.
+    :param duration: The duration in seconds to add to the start time.
+    :return: The computed end time in ISO 8601 format with a "+0000" timezone offset.
+    """
+    if "+" not in start_time:
+        start_time += "+0000"
+    start_time_obj = datetime.strptime(start_time, "%Y-%m-%dT%H:%M:%S+0000")
+    end_time_obj = start_time_obj + timedelta(seconds=duration)
+    return end_time_obj.replace(microsecond=0).isoformat() + "+0000"
+
+
+def convert_time_to_xray_format(original_time: str) -> str:
+    """
+    Converts a given time string from the format "YYYY-MM-DDTHH:MM:SS" to the
+    format "YYYY-MM-DDTHH:MM:SS+0000" by appending the UTC offset.
+
+    :param original_time: The original time string in the format "YYYY-MM-DDTHH:MM:SS".
+    :return: The converted time string in the format "YYYY-MM-DDTHH:MM:SS+0000".
+    """
+    if "+0000" not in original_time:
+        return original_time + "+0000"
+    return original_time
+
+
+def create_result_dictionary(test_suites: dict) -> dict:
+    """
+    Processes test suite data and generates a dictionary containing information
+    about the test execution and individual test cases for Xray integration.
+    :param test_suites: A dictionary containing test suite data. Each test suite
+            should include details such as errors, failures, time, timestamp, and
+            test cases.
+    :return: A dictionary with two keys:
+            - "info": Contains metadata about the test execution, including summary,
+              description, start date, finish date, and project key.
+            - "tests": A list of dictionaries, each representing an individual test
+              case with its test key, status, and comments.
+    Notes:
+        - The function assumes that the `testcase` field in the input can either be
+          a single dictionary or a list of dictionaries. If it's a single dictionary,
+          it is converted into a list for uniform processing.
+        - The `properties` field of each test case is used to extract the test key.
+        - The test execution status is determined based on the presence of failure
+          or error logs.
+        - The `convert_time_to_xray_format` and `compute_end_time` helper functions
+          are used to calculate and format timestamps.
+    """
+    # filter xml file to keep only the info with properties
+    xray_test_ticket = {}
+    test_execution_ticket = {}
+    xray_test_ticket_list = []
+
+    for testsuite in test_suites:
+        # all the testsuite -> build the test execution info
+        has_errors = True if int(testsuite["errors"]) > 0 else False
+        has_failures = True if int(testsuite["failures"]) > 0 else False
+        duration = float(testsuite["time"])  # sec
+        start_time = convert_time_to_xray_format(testsuite["timestamp"])  # str
+        end_time = compute_end_time(start_time=start_time, duration=duration)  # str
+        summary = "Xray test execution summary"
+        description = "Xray test execution description"
+
+        test_execution_ticket = {
+            "summary": summary,
+            "description": description,
+            "startDate": start_time,
+            "finishDate": end_time,
+        }
+
+        if not isinstance(testsuite["testcase"], list):
+            # if there is only one test case, it is not a list
+            testcase = testsuite["testcase"]
+            testsuite["testcase"] = [testcase]
+
+        for testcase in testsuite["testcase"]:
+            # for each test case -> build the xray test info
+            name = testcase.get("name")
+            if name == "test_run":
+                continue
+
+            # keep only test cases with a test_key in the decorator
+            properties = testcase.get("properties")
+            if properties is None:
+                continue
+
+            test_key = get_test_key_from_property(properties["property"])
+            duration = float(testcase["time"])  # sec
+            start_time = convert_time_to_xray_format(testcase["timestamp"])
+            end_time = compute_end_time(start_time=start_time, duration=duration)
+            # get failure or error logs
+            failure_logs = testcase.get("failure")
+            error_logs = testcase.get("error")
+            # get the test status
+            is_failed = True if failure_logs and has_failures else False
+            is_error = True if error_logs and has_errors else False
+            if is_failed:
+                comment = failure_logs["#text"]
+            elif is_error:
+                comment = error_logs["#text"]
+            elif failure_logs == error_logs:
+                comment = "Successful execution"
+            else:
+                raise ValueError("Test should has failed or passed. Not both.")
+            status = "PASSED" if not is_failed and not is_error else "FAILED"
+
+            xray_test_ticket = {
+                "testKey": test_key,
+                "comment": name + ": " + comment,
+                "status": status,
+            }
+            xray_test_ticket_list.append(xray_test_ticket)
+
+    # update project key
+    project_key = xray_test_ticket["testKey"].split("-")[0]
+    test_execution_ticket["project"] = project_key
+    return {"info": test_execution_ticket, "tests": xray_test_ticket_list}
+
+
+def is_parameterized_test(test_results: dict) -> bool:
+    """
+    Check if the test is parameterized. The test is parametrized if several times there are the same test_key.
+    :param test_results: The test results to check.
+
+    :return: True if the test is parameterized, False otherwise.
+    """
+    test_keys_list = [test["testKey"] for test in test_results["tests"]]  # Extract all test keys
+    test_keys_set = {test["testKey"] for test in test_results["tests"]}  # Extract unique test keys
+    return len(test_keys_list) != len(test_keys_set)
+
+
+def reformat_xml_results(test_results: dict, test_execution_id: str | None = None) -> list[dict]:
+    """
+    Reformats a list of XML results dictionaries by merging them based on their 'testKey' key.
+
+    :param test_results: A list of dictionaries where each dictionary contains 'info' (a dictionary of test metadata)
+        and 'tests' (a list of test cases).
+    :param test_execution_id: the xray's test execution ticket id where to import the test results,
+        if none is specified a new test execution ticket will be created
+
+    :return: A list of merged test result dictionaries. Each dictionary contains 'info' (a dictionary of test metadata)
+        and 'tests' (a combined list of test cases from all input dictionaries with the same 'info').
+    """
+    test_execution_ticket = test_results["info"]
+    if is_parameterized_test(test_results=test_results):
+        xray_test_ticket_new = merge_test_results_comments(test_results["tests"])
+        parameterized_test_results = {"info": test_execution_ticket, "tests": xray_test_ticket_new}
+        if test_execution_id is not None:
+            parameterized_test_results["testExecutionKey"] = test_execution_id
+        return [parameterized_test_results]
+    else:
+        if test_execution_id is not None:
+            test_results["testExecutionKey"] = test_execution_id
+        return [test_results]
+
+
+def merge_test_results_comments(test_results: list) -> list:
+    """
+    Merges test results with the same test key by combining their comments and determining the overall status.
+
+    :param test_results: A list of dictionaries where each dictionary represents a test result.
+        Each test result dictionary should have the following keys:
+        - "testKey" (str): The unique identifier for the test.
+        - "comment" (str): A comment associated with the test result.
+        - "status" (str): The status of the test, either "PASSED" or "FAILED".
+    :return: A list of merged test result dictionaries. Each dictionary contains:
+        - "testKey" (str): The unique identifier for the test.
+        - "comment" (str): The combined comments for all test results with the same test key.
+        - "status" (str): The overall status for the test key, which is "FAILED" if any test with the same key has a status of "FAILED", otherwise "PASSED".
+    """
+    merged_results = {}
+    for test in test_results:
+        test_key = test["testKey"]
+        if test_key not in merged_results:
+            merged_results[test_key] = {"testKey": test_key, "comment": "", "status": "PASSED"}
+        # Append the comment
+        if merged_results[test_key]["comment"]:
+            merged_results[test_key]["comment"] += "\n"
+        merged_results[test_key]["comment"] += test["comment"]
+
+        # Update the status to FAILED if any test with the same testKey has FAILED
+        if test["status"] == "FAILED":
+            merged_results[test_key]["status"] = "FAILED"
+
+    # Convert the merged results back to a list
+    return list(merged_results.values())

--- a/tests/test_xray.py
+++ b/tests/test_xray.py
@@ -1,0 +1,254 @@
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from pykiso.tool.xray.xray import (
+    ClientSecretAuth,
+    XrayException,
+    XrayPublisher,
+    extract_test_results,
+    upload_test_results,
+)
+
+
+def test_client_secret_auth_endpoint_url():
+    auth = ClientSecretAuth(base_url="https://example.com/", client_id="id", client_secret="secret")
+    assert auth.endpoint_url == "https://example.com/api/v2/authenticate"
+
+
+@patch("pykiso.tool.xray.xray.requests.post")
+def test_client_secret_auth_call(mock_post):
+    mock_response = MagicMock()
+    mock_response.text = '"token"'
+    mock_post.return_value = mock_response
+
+    auth = ClientSecretAuth(base_url="https://example.com", client_id="id", client_secret="secret")
+    request = MagicMock()
+    request.headers = {}
+    auth(request)
+
+    mock_post.assert_called_once_with(
+        "https://example.com/api/v2/authenticate",
+        data='{"client_id": "id", "client_secret": "secret"}',
+        headers={"Content-type": "application/json", "Accept": "text/plain"},
+        verify=True,
+    )
+    assert request.headers["Authorization"] == "Bearer token"
+
+
+@patch("pykiso.tool.xray.xray.requests.request")
+def test_publish_xml_result(mock_request):
+    mock_response = MagicMock()
+    mock_response.content = '{"id": "123", "key": "TEST-1", "issue": "Issue"}'
+    mock_request.return_value = mock_response
+
+    auth = MagicMock()
+    publisher = XrayPublisher(base_url="https://example.com", endpoint="/endpoint", auth=auth)
+    result = publisher.publish_xml_result(data={"key": "value"})
+
+    mock_request.assert_called_once_with(
+        method="POST",
+        url="/endpoint",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={"key": "value"},
+        auth=auth,
+        verify=True,
+    )
+    assert result == {"id": "123", "key": "TEST-1", "issue": "Issue"}
+
+
+@patch("pykiso.tool.xray.xray.requests.request")
+def test_publish_xml_result_connection_error(mock_request):
+    mock_request.side_effect = requests.exceptions.ConnectionError
+
+    publisher = XrayPublisher(
+        base_url="https://example.com",
+        endpoint="/endpoint",
+        auth=MagicMock(),
+    )
+
+    with pytest.raises(XrayException, match="Cannot connect to JIRA service at /endpoint"):
+        publisher._publish_xml_result(data={"key": "value"})
+
+
+@patch("pykiso.tool.xray.xray.requests.post")
+def test_upload_test_results(mock_post):
+    mock_response = MagicMock()
+    mock_response.text = '"token"'
+    mock_post.return_value = mock_response
+
+    mock_publisher = MagicMock()
+    mock_publisher.publish_xml_result.return_value = {"id": "123", "key": "TEST-1", "issue": "Issue"}
+
+    with patch("pykiso.tool.xray.xray.ClientSecretAuth", return_value=MagicMock()) as mock_auth, patch(
+        "pykiso.tool.xray.xray.XrayPublisher", return_value=mock_publisher
+    ):
+        result = upload_test_results(
+            base_url="https://example.com",
+            user="user",
+            password="password",
+            results={"key": "value"},
+        )
+
+    mock_auth.assert_called_once_with(
+        base_url="https://example.com", client_id="user", client_secret="password", verify=True
+    )
+    mock_publisher.publish_xml_result.assert_called_once_with(
+        data={"key": "value"}, project_key=None, test_execution_name=None
+    )
+    assert result == {"id": "123", "key": "TEST-1", "issue": "Issue"}
+
+
+def test_extract_test_results_with_valid_file(mocker):
+    mocker.patch("pykiso.tool.xray.xray.create_result_dictionary", return_value={"key": "value"})
+    mocker.patch("pykiso.tool.xray.xray.reformat_xml_results", return_value=["formatted_result"])
+
+    xml_content = """<testsuites>
+        <testsuite>
+            <testcase classname="test_class" name="test_name" />
+        </testsuite>
+    </testsuites>"""
+
+    with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as temp_file:
+        temp_file.write(xml_content.encode())
+        temp_file_path = Path(temp_file.name)
+
+    results = extract_test_results(
+        path_results=temp_file_path,
+        merge_xml_files=False,
+        update_description=False,
+        test_execution_id=None,
+    )
+
+    assert results == ["formatted_result"]
+
+
+def test_extract_test_results_with_invalid_file_extension():
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as temp_file:
+        temp_file_path = Path(temp_file.name)
+
+    with pytest.raises(RuntimeError, match="Expected xml file but found a .txt file instead"):
+        extract_test_results(
+            path_results=temp_file_path,
+            merge_xml_files=False,
+            update_description=False,
+            test_execution_id=None,
+        )
+
+
+def test_xray_exception_message():
+    exception = XrayException(message="Test error message")
+    assert exception.message == "Test error message"
+
+
+@patch("pykiso.tool.xray.xray.requests.post")
+def test_client_secret_auth_call_connection_error(mock_post):
+    mock_post.side_effect = requests.exceptions.ConnectionError
+
+    auth = ClientSecretAuth(base_url="https://example.com", client_id="test_id", client_secret="test_secret")
+    request = MagicMock()
+
+    with pytest.raises(
+        XrayException, match="ConnectionError: cannot authenticate with https://example.com/api/v2/authenticate"
+    ):
+        auth(request)
+
+
+@patch("pykiso.tool.xray.xray.requests.post")
+def test_client_secret_auth_call_invalid_token(mock_post):
+    mock_response = MagicMock()
+    mock_response.text = '"invalid_token"'
+    mock_post.return_value = mock_response
+
+    auth = ClientSecretAuth(base_url="https://example.com", client_id="test_id", client_secret="test_secret")
+    request = MagicMock()
+    request.headers = {}
+
+    auth(request)
+
+    assert request.headers["Authorization"] == "Bearer invalid_token"
+
+
+def test_xray_publisher_endpoint_url():
+    publisher = XrayPublisher(
+        base_url="https://example.com/",
+        endpoint="/endpoint",
+        auth=MagicMock(),
+    )
+    assert publisher.endpoint_url == "https://example.com/endpoint"
+
+
+@patch("pykiso.tool.xray.xray.requests.post")
+def test_publish_xml_result_multipart_success(mock_post):
+    mock_response = MagicMock()
+    mock_response.content = '{"id": "123", "key": "TEST-1", "issue": "Issue"}'
+    mock_post.return_value = mock_response
+
+    publisher = XrayPublisher(
+        base_url="https://example.com",
+        endpoint="/endpoint",
+        auth=MagicMock(),
+    )
+
+    data = {"key": "value"}
+    project_key = "PROJ"
+    test_execution_name = "Test Execution Name"
+
+    result = publisher._publish_xml_result_multipart(
+        data=data,
+        project_key=project_key,
+        test_execution_name=test_execution_name,
+    )
+
+    mock_post.assert_called_once_with(
+        "https://example.com/api/v2/import/execution/junit/multipart",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        files={
+            "info": json.dumps(
+                {
+                    "fields": {
+                        "project": {"key": project_key},
+                        "summary": test_execution_name,
+                        "issuetype": {"name": "Xray Test Execution"},
+                    }
+                }
+            ),
+            "results": data,
+            "testInfo": json.dumps(
+                {
+                    "fields": {
+                        "project": {"key": project_key},
+                        "summary": test_execution_name,
+                        "issuetype": {"id": None},
+                    }
+                }
+            ),
+        },
+    )
+    assert result == {"id": "123", "key": "TEST-1", "issue": "Issue"}
+
+
+@patch("pykiso.tool.xray.xray.requests.post")
+def test_publish_xml_result_multipart_connection_error(mock_post):
+    mock_post.side_effect = requests.exceptions.ConnectionError
+
+    publisher = XrayPublisher(
+        base_url="https://example.com",
+        endpoint="/endpoint",
+        auth=MagicMock(),
+    )
+
+    data = {"key": "value"}
+    project_key = "PROJ"
+    test_execution_name = "Test Execution Name"
+
+    with pytest.raises(XrayException, match="Cannot connect to JIRA service at import/execution/junit/multipart"):
+        publisher._publish_xml_result_multipart(
+            data=data,
+            project_key=project_key,
+            test_execution_name=test_execution_name,
+        )

--- a/tests/test_xray_report.py
+++ b/tests/test_xray_report.py
@@ -1,0 +1,355 @@
+import pytest
+
+from pykiso.tool.xray.xray_report import (
+    compute_end_time,
+    convert_test_status_to_xray_format,
+    convert_time_to_xray_format,
+    create_result_dictionary,
+    get_test_key_from_property,
+    is_parameterized_test,
+    merge_results,
+    reformat_xml_results,
+)
+
+
+def test_convert_time_to_xray_format():
+    original_time = "2021-12-25T15:30:45"
+    expected_time = "2021-12-25T15:30:45+0000"
+    assert convert_time_to_xray_format(original_time) == expected_time
+
+
+@pytest.mark.parametrize("status,expected_status", ([True, "PASSED"], [False, "FAILED"]))
+def test_convert_test_status_to_xray_format_passed(status, expected_status):
+    assert convert_test_status_to_xray_format(status) == expected_status
+
+
+def test_convert_test_status_to_xray_format_failed():
+    assert convert_test_status_to_xray_format(False) == "FAILED"
+
+
+def test_merge_results():
+    test_results = [
+        {
+            "info": {"project": "PROJ1", "summary": "Test Summary 1"},
+            "tests": [{"testKey": "TEST-1", "status": "PASSED"}],
+        },
+        {
+            "info": {"project": "PROJ1", "summary": "Test Summary 1"},
+            "tests": [{"testKey": "TEST-2", "status": "FAILED"}],
+        },
+        {
+            "info": {"project": "PROJ2", "summary": "Test Summary 2"},
+            "tests": [{"testKey": "TEST-3", "status": "PASSED"}],
+        },
+    ]
+
+    expected_merged_results = [
+        {
+            "info": {"project": "PROJ1", "summary": "Test Summary 1"},
+            "tests": [
+                {"testKey": "TEST-1", "status": "PASSED"},
+                {"testKey": "TEST-2", "status": "FAILED"},
+            ],
+        },
+        {
+            "info": {"project": "PROJ2", "summary": "Test Summary 2"},
+            "tests": [{"testKey": "TEST-3", "status": "PASSED"}],
+        },
+    ]
+
+    merged_results = merge_results(test_results)
+    assert merged_results == expected_merged_results
+
+
+def test_get_test_key_from_property_with_valid_property():
+    properties = [
+        {"name": "test_key", "value": "TEST-123"},
+        {"name": "other_key", "value": "OTHER-456"},
+    ]
+    assert get_test_key_from_property(properties) == "TEST-123"
+
+
+def test_get_test_key_from_property_with_missing_test_key():
+    properties = [
+        {"name": "other_key", "value": "OTHER-456"},
+        {"name": "another_key", "value": "ANOTHER-789"},
+    ]
+    assert get_test_key_from_property(properties) is None
+
+
+def test_compute_end_time_with_valid_input():
+    start_time = "2023-01-01T12:00:00"
+    duration = 3600  # 1 hour in seconds
+    expected_end_time = "2023-01-01T13:00:00+0000"
+    assert compute_end_time(start_time, duration) == expected_end_time
+
+
+def test_compute_end_time_with_timezone_in_start_time():
+    start_time = "2023-01-01T12:00:00+0000"
+    duration = 1800  # 30 minutes in seconds
+    expected_end_time = "2023-01-01T12:30:00+0000"
+    assert compute_end_time(start_time, duration) == expected_end_time
+
+
+def test_compute_end_time_with_zero_duration():
+    start_time = "2023-01-01T12:00:00"
+    duration = 0  # No duration
+    expected_end_time = "2023-01-01T12:00:00+0000"
+    assert compute_end_time(start_time, duration) == expected_end_time
+
+
+def test_compute_end_time_with_invalid_start_time_format():
+    start_time = "2023-01-01 12:00:00"  # Invalid format
+    duration = 3600
+    with pytest.raises(ValueError):
+        compute_end_time(start_time, duration)
+
+
+def test_create_result_dictionary_with_single_testcase():
+    test_suites = [
+        {
+            "errors": "0",
+            "failures": "0",
+            "time": "10.5",
+            "timestamp": "2023-01-01T12:00:00",
+            "testcase": {
+                "name": "test_case_1",
+                "time": "10.5",
+                "timestamp": "2023-01-01T12:00:00",
+                "properties": {"property": [{"name": "test_key", "value": "TEST-1"}]},
+            },
+        }
+    ]
+
+    expected_result = {
+        "info": {
+            "summary": "Xray test execution summary",
+            "description": "Xray test execution description",
+            "startDate": "2023-01-01T12:00:00+0000",
+            "finishDate": "2023-01-01T12:00:10+0000",
+            "project": "TEST",
+        },
+        "tests": [
+            {
+                "testKey": "TEST-1",
+                "comment": "test_case_1: Successful execution",
+                "status": "PASSED",
+            }
+        ],
+    }
+
+    assert create_result_dictionary(test_suites) == expected_result
+
+
+def test_create_result_dictionary_with_multiple_testcases():
+    test_suites = [
+        {
+            "errors": "0",
+            "failures": "1",
+            "time": "20.0",
+            "timestamp": "2023-01-01T12:00:00",
+            "testcase": [
+                {
+                    "name": "test_case_1",
+                    "time": "10.0",
+                    "timestamp": "2023-01-01T12:00:00",
+                    "properties": {"property": [{"name": "test_key", "value": "TEST-1"}]},
+                },
+                {
+                    "name": "test_case_2",
+                    "time": "10.0",
+                    "timestamp": "2023-01-01T12:10:00",
+                    "properties": {"property": [{"name": "test_key", "value": "TEST-2"}]},
+                    "failure": {"#text": "Test failed due to an error."},
+                },
+            ],
+        }
+    ]
+
+    expected_result = {
+        "info": {
+            "summary": "Xray test execution summary",
+            "description": "Xray test execution description",
+            "startDate": "2023-01-01T12:00:00+0000",
+            "finishDate": "2023-01-01T12:00:20+0000",
+            "project": "TEST",
+        },
+        "tests": [
+            {
+                "testKey": "TEST-1",
+                "comment": "test_case_1: Successful execution",
+                "status": "PASSED",
+            },
+            {
+                "testKey": "TEST-2",
+                "comment": "test_case_2: Test failed due to an error.",
+                "status": "FAILED",
+            },
+        ],
+    }
+
+    assert create_result_dictionary(test_suites) == expected_result
+
+
+def test_create_result_dictionary_with_missing_properties():
+    test_suites = [
+        {
+            "errors": "0",
+            "failures": "0",
+            "time": "5.0",
+            "timestamp": "2023-01-01T12:00:00",
+            "testcase": {
+                "name": "test_case_1",
+                "time": "5.0",
+                "timestamp": "2023-01-01T12:00:00",
+            },
+        }
+    ]
+
+    with pytest.raises(KeyError):
+        create_result_dictionary(test_suites)
+
+
+def test_create_result_dictionary_with_error_logs():
+    test_suites = [
+        {
+            "errors": "1",
+            "failures": "0",
+            "time": "15.0",
+            "timestamp": "2023-01-01T12:00:00",
+            "testcase": {
+                "name": "test_case_1",
+                "time": "15.0",
+                "timestamp": "2023-01-01T12:00:00",
+                "properties": {"property": [{"name": "test_key", "value": "TEST-1"}]},
+                "error": {"#text": "An unexpected error occurred."},
+            },
+        }
+    ]
+
+    expected_result = {
+        "info": {
+            "summary": "Xray test execution summary",
+            "description": "Xray test execution description",
+            "startDate": "2023-01-01T12:00:00+0000",
+            "finishDate": "2023-01-01T12:00:15+0000",
+            "project": "TEST",
+        },
+        "tests": [
+            {
+                "testKey": "TEST-1",
+                "comment": "test_case_1: An unexpected error occurred.",
+                "status": "FAILED",
+            }
+        ],
+    }
+
+    assert create_result_dictionary(test_suites) == expected_result
+
+
+def test_is_parameterized_test_with_non_parameterized_tests():
+    test_results = {
+        "tests": [
+            {"testKey": "TEST-1", "status": "PASSED"},
+            {"testKey": "TEST-2", "status": "FAILED"},
+            {"testKey": "TEST-3", "status": "PASSED"},
+        ]
+    }
+    assert not is_parameterized_test(test_results)
+
+
+def test_is_parameterized_test_with_parameterized_tests():
+    test_results = {
+        "tests": [
+            {"testKey": "TEST-1", "status": "PASSED"},
+            {"testKey": "TEST-1", "status": "FAILED"},
+            {"testKey": "TEST-2", "status": "PASSED"},
+        ]
+    }
+    assert is_parameterized_test(test_results)
+
+
+def test_is_parameterized_test_with_empty_tests():
+    test_results = {"tests": []}
+    assert not is_parameterized_test(test_results)
+
+
+def test_is_parameterized_test_with_single_test():
+    test_results = {"tests": [{"testKey": "TEST-1", "status": "PASSED"}]}
+    assert not is_parameterized_test(test_results)
+
+
+def test_reformat_xml_results_with_parameterized_tests():
+    test_results = {
+        "info": {
+            "summary": "Test Execution Summary",
+            "description": "Test Execution Description",
+            "startDate": "2023-01-01T12:00:00+0000",
+            "finishDate": "2023-01-01T12:30:00+0000",
+            "project": "TEST",
+        },
+        "tests": [
+            {"testKey": "TEST-1", "comment": "test_case_1: Successful execution", "status": "PASSED"},
+            {"testKey": "TEST-1", "comment": "test_case_2: Traceback error", "status": "FAILED"},
+        ],
+    }
+    test_execution_id = None
+
+    expected_result = [
+        {
+            "info": {
+                "summary": "Test Execution Summary",
+                "description": "Test Execution Description",
+                "startDate": "2023-01-01T12:00:00+0000",
+                "finishDate": "2023-01-01T12:30:00+0000",
+                "project": "TEST",
+            },
+            "tests": [
+                {
+                    "testKey": "TEST-1",
+                    "comment": "test_case_1: Successful execution\ntest_case_2: Traceback error",
+                    "status": "FAILED",
+                },
+            ],
+        },
+    ]
+
+    result = reformat_xml_results(test_results, test_execution_id)
+    assert result == expected_result
+
+
+def test_reformat_xml_results_with_non_parameterized_tests():
+    test_results = {
+        "info": {
+            "summary": "Test Execution Summary",
+            "description": "Test Execution Description",
+            "startDate": "2023-01-01T12:00:00+0000",
+            "finishDate": "2023-01-01T12:30:00+0000",
+            "project": "TEST",
+        },
+        "tests": [
+            {"testKey": "TEST-1", "comment": "test_case_1: Successful execution", "status": "PASSED"},
+            {"testKey": "TEST-2", "comment": "test_case_2: Failed execution", "status": "FAILED"},
+        ],
+    }
+    test_execution_id = "TEST-EXEC-123"
+
+    expected_result = [
+        {
+            "info": {
+                "summary": "Test Execution Summary",
+                "description": "Test Execution Description",
+                "startDate": "2023-01-01T12:00:00+0000",
+                "finishDate": "2023-01-01T12:30:00+0000",
+                "project": "TEST",
+            },
+            "tests": [
+                {"testKey": "TEST-1", "comment": "test_case_1: Successful execution", "status": "PASSED"},
+                {"testKey": "TEST-2", "comment": "test_case_2: Failed execution", "status": "FAILED"},
+            ],
+            "testExecutionKey": "TEST-EXEC-123",
+        }
+    ]
+
+    result = reformat_xml_results(test_results, test_execution_id)
+    assert result == expected_result


### PR DESCRIPTION
The goal of this POC is to change the way to upload test results to xray, before 2 steps were required first step run the test and generate the jjunit xml file at the same time then second step convert this junit into a junit compatible with xray to upload the test results. The parameterized were not supported. This way only worked with xray test ticket with a Generic type and not with Manual, Automated and automated Cucumber types.

The user still uses a decorator with the test_key ID of the xray test ticket 
- if the pykiso test does not use parameterized
- only test execution ticket will be create in xray for all the test function and linked to the xray test tickets
- if the pykiso test use parameterized
- one test execution ticket will be created in xray per test function and per parameters

HTML step report generation has also been updated and support parameterized tests.