### PR TITLE
feat: add not_append_test_results flag to xray cli

### DIFF
--- a/src/pykiso/tool/xray/cli.py
+++ b/src/pykiso/tool/xray/cli.py
@@ -76,6 +76,14 @@ def cli_xray(ctx: dict, user: str, password: str, url: str) -> None:
     is_flag=True,
     required=False,
 )
+@click.option(
+    "-na",
+    "--not-append-test-results",
+    help="Do not append new test keys from the .xml(s) to the updated test execution, only overwrite already existing ones",
+    is_flag=True,
+    default=False,
+    required=False,
+)
 @click.pass_context
 def cli_upload(
     ctx,
@@ -84,6 +92,7 @@ def cli_upload(
     test_execution_description: str,
     test_execution_summary: str,
     merge_xml_files: bool,
+    not_append_test_results: bool,
 ) -> None:
     """Upload the JUnit xml test results on xray.
 
@@ -93,6 +102,7 @@ def cli_upload(
     :param test_execution_description: update the test execution ticket description - otherwise, keep current description
     :param test_execution_summary: update the test execution ticket summary - otherwise, keep current summary
     :param merge_xml_files: if True, merge the xml files, else do nothing
+    :param not_append_test_results: if True, only overwrite the existing ones (update only), else append the new results from the .xml file(s) to the test execution
 
     """
     # If a new test execution ticket is being created (no key), the user should pass a description and a summary.
@@ -104,8 +114,10 @@ def cli_upload(
     # From the JUnit xml files found, create a list of the dictionary per test results marked with an xray decorator.
     path_results = Path(path_results).resolve()
     test_results = extract_test_results(
+        ctx,
         path_results=path_results,
         merge_xml_files=merge_xml_files,
+        not_append_test_results=not_append_test_results,
         test_execution_key=test_execution_key,
         test_execution_summary=test_execution_summary,
         test_execution_description=test_execution_description,

--- a/src/pykiso/tool/xray/xray_report.py
+++ b/src/pykiso/tool/xray/xray_report.py
@@ -97,7 +97,10 @@ def convert_time_to_xray_format(original_time: str) -> str:
 
 
 def create_result_dictionary(
-    test_suites: dict, test_execution_summary: str | None = None, test_execution_description: str | None = None
+    test_suites: dict,
+    jira_keys: list[str],
+    test_execution_summary: str | None = None,
+    test_execution_description: str | None = None,
 ) -> dict:
     """
     Processes test suite data and generates a dictionary containing information
@@ -160,6 +163,10 @@ def create_result_dictionary(
                 continue
 
             test_key = get_test_key_from_property(properties["property"])
+            if jira_keys:
+                # skip the keys not in the jira_keys list if any
+                if test_key not in jira_keys:
+                    continue
             duration = float(testcase["time"])  # sec
             start_time = convert_time_to_xray_format(testcase["timestamp"])
             end_time = compute_end_time(start_time=start_time, duration=duration)


### PR DESCRIPTION
When we update the results in an existing Test Execution Ticket with an xml file, 2 behaviours:
- if the Xray IDs are different between those present in the xml file and the existing Test Execution Ticket → all the xml content is appended to the existing ticket
- if the Xray IDs are similar between those present in the xml file and the existing Test Execution Ticket → the ticket is updated

The goal is to add a flag to the cli,
- if the flag is set, just update the test results corresponding to the existing Xray IDs already present in the test execution ticket
- if the flag is not set, append the test execution ticket with everything (even the results with Xray IDs no present in the test execution ticket)