### PR TITLE
fix: active_loggers list keep increasing in size in initialize loggers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykiso"
-version = "1.5.0"
+version = "1.5.1"
 description = "Embedded integration testing framework."
 authors = ["Sebastian Fischer <sebastian.fischer@de.bosch.com>"]
 license = "Eclipse Public License - v 2.0"

--- a/src/pykiso/logging_initializer.py
+++ b/src/pykiso/logging_initializer.py
@@ -24,6 +24,7 @@ import re
 import sys
 import time
 from ast import literal_eval
+from copy import deepcopy
 from functools import partialmethod, wraps
 from pathlib import Path
 from typing import List, NamedTuple, Optional, Union
@@ -203,6 +204,9 @@ def initialize_loggers(loggers: Optional[List[str]]) -> None:
     global active_loggers
     if loggers is None:
         loggers = list()
+    else:
+        loggers = deepcopy(loggers)
+
     # keyword 'all' should keep all loggers to the configured level
     if "all" in loggers:
         logging.internal_warning("All loggers are activated, this could lead to performance issues.")


### PR DESCRIPTION
Fix case where if in a yaml the following lines are defined 
```yaml
logs: &activate_log
  activate_log:
    - ebplugins
    - ebcan
```

And are called in the config of multiple auxiliaries like 

```yaml
com_aux:
    connectors:
        com: can_channel
    config:
      auto_start: False
      <<: *activate_log
    type: pykiso.lib.auxiliaries.communication_auxiliary:CommunicationAuxiliary
```

The list activate log then keep increasing in size and make the `initialize_loggers` function take a lot of time

